### PR TITLE
dump walkers periodically for post-processing 

### DIFF
--- a/src/Particle/HDFWalkerOutput.cpp
+++ b/src/Particle/HDFWalkerOutput.cpp
@@ -107,6 +107,28 @@ bool HDFWalkerOutput::dump(const WalkerConfigurations& W, int nblock)
   return true;
 }
 
+bool HDFWalkerOutput::record(const WalkerConfigurations& W, int nblock)
+{
+  std::string FileName=myComm->getName()+hdf::config_ext;
+
+  //try to use collective
+  hdf_archive dump_file(myComm,true);
+  bool success = dump_file.open(FileName);
+
+  // YY: error handling, should this be moved to the driver?
+  if (!success)
+  { // if config.h5 cannot be opened, then let dump() create new config.h5
+    return dump(W, nblock);
+  }
+
+  write_configuration(W,dump_file, nblock, true);
+  dump_file.close();
+
+  currentConfigNumber++;
+  prevFile=FileName;
+  return true;
+}
+
 void HDFWalkerOutput::write_configuration(const WalkerConfigurations& W, hdf_archive& hout, int nblock, bool identify_block)
 {
   std::string dataset_name = hdf::walkers;

--- a/src/Particle/HDFWalkerOutput.h
+++ b/src/Particle/HDFWalkerOutput.h
@@ -39,19 +39,15 @@ class HDFWalkerOutput
   const size_t number_of_particles_;
   ///communicator
   Communicate* myComm;
-  int currentConfigNumber;
   ///rootname
   std::string RootName;
-  std::string prevFile;
-  //     ///handle for the storeConfig.h5
-  //     hdf_archive fw_out;
 public:
   ///constructor
   HDFWalkerOutput(size_t num_ptcls, const std::string& fname, Communicate* c);
   ///destructor
   ~HDFWalkerOutput();
 
-  /** dump configurations for checkpoint (overwrite file)
+  /** dump configurations
    * @param w walkers
    */
   bool dump(const WalkerConfigurations& w, int block, const bool identify_block=false);

--- a/src/Particle/HDFWalkerOutput.h
+++ b/src/Particle/HDFWalkerOutput.h
@@ -54,11 +54,7 @@ public:
   /** dump configurations for checkpoint (overwrite file)
    * @param w walkers
    */
-  bool dump(const WalkerConfigurations& w, int block);
-  /** record configurations for post-processing (append to file)
-   * @param w walkers
-   */
-  bool record(const WalkerConfigurations& w, int block);
+  bool dump(const WalkerConfigurations& w, int block, const bool identify_block=false);
   //     bool dump(ForwardWalkingHistoryObject& FWO);
 
 private:
@@ -68,7 +64,7 @@ private:
   std::array<BufferType, 2> RemoteData;
   std::array<std::vector<QMCTraits::FullPrecRealType>, 2> RemoteDataW;
   int block;
-  void write_configuration(const WalkerConfigurations& W, hdf_archive& hout, int block, bool identify_block);
+  void write_configuration(const WalkerConfigurations& W, hdf_archive& hout, int block, const bool identify_block);
 };
 
 } // namespace qmcplusplus

--- a/src/Particle/HDFWalkerOutput.h
+++ b/src/Particle/HDFWalkerOutput.h
@@ -51,10 +51,14 @@ public:
   ///destructor
   ~HDFWalkerOutput();
 
-  /** dump configurations
+  /** dump configurations for checkpoint (overwrite file)
    * @param w walkers
    */
   bool dump(const WalkerConfigurations& w, int block);
+  /** record configurations for post-processing (append to file)
+   * @param w walkers
+   */
+  bool record(const WalkerConfigurations& w, int block);
   //     bool dump(ForwardWalkingHistoryObject& FWO);
 
 private:

--- a/src/Particle/HDFWalkerOutput.h
+++ b/src/Particle/HDFWalkerOutput.h
@@ -64,7 +64,7 @@ private:
   std::array<BufferType, 2> RemoteData;
   std::array<std::vector<QMCTraits::FullPrecRealType>, 2> RemoteDataW;
   int block;
-  void write_configuration(const WalkerConfigurations& W, hdf_archive& hout, int block);
+  void write_configuration(const WalkerConfigurations& W, hdf_archive& hout, int block, bool identify_block);
 };
 
 } // namespace qmcplusplus

--- a/src/QMCDrivers/QMCDriver.cpp
+++ b/src/QMCDrivers/QMCDriver.cpp
@@ -311,6 +311,11 @@ void QMCDriver::recordBlock(int block)
     RandomNumberControl::write(RootName, myComm);
     checkpointTimer->stop();
   }
+  if (Period4ConfigDump!=0 && block%Period4ConfigDump == 0)
+  { // append current walkers to config.h5
+    const bool identify_block = true;
+    wOut->dump(W, block, identify_block);
+  }
 }
 
 bool QMCDriver::finalize(int block, bool dumpwalkers)


### PR DESCRIPTION
**Warning** unlinking datasets in hdf5 creates memory leak
In practice, don't checkpoint too often and it should be fine.